### PR TITLE
MCP Trust Score

### DIFF
--- a/.cursor 2/rules/000_general.mdc
+++ b/.cursor 2/rules/000_general.mdc
@@ -1,0 +1,28 @@
+---
+description: General project guidelines for tfmcp. Always consider these guidelines when working on the project.
+globs: *
+alwaysApply: true
+---
+
+# General Project Guidelines
+
+## Project Overview
+- This is tfmcp (Terraform Model Context Protocol Tool), a CLI tool that helps you interact with Terraform via MCP.
+- The project is written in Rust and integrates with Terraform to enable AI-assisted infrastructure management.
+- Always maintain high code quality and adherence to best practices.
+
+## Development Workflow
+- Follow semantic versioning for releases.
+- Use the Release.sh script for versioning and releases.
+- Write meaningful commit messages following conventional commits format.
+
+## Documentation
+- Keep documentation up-to-date as features evolve.
+- Document public APIs, functions, and modules.
+- Include examples where appropriate.
+
+## Testing
+- Write unit tests for core functionality.
+- Ensure test coverage for critical paths.
+- Test against different Terraform versions when applicable. 
+

--- a/.cursor 2/rules/001_rust.mdc
+++ b/.cursor 2/rules/001_rust.mdc
@@ -1,0 +1,63 @@
+---
+description: Rust coding standards and architecture guidelines for tfmcp.
+globs: **/*.rs
+alwaysApply: false
+---
+
+# Rust Coding Style Guide
+
+## Code Style
+- Follow the Rust style guide as enforced by `rustfmt` and `cargo fmt`.
+- Use 4 spaces for indentation, not tabs.
+- Maximum line length is 100 characters.
+- Always run `cargo fmt` before committing code.
+
+## Error Handling
+- Use `Result` and `Option` types appropriately.
+- Propagate errors with the `?` operator where appropriate.
+- Create custom error types in modules with complex error handling.
+- Use `thiserror` for defining error types.
+- Use `anyhow` for error propagation in application code.
+
+## Documentation
+- Document all public functions, methods, and types with rustdoc comments.
+- Include examples in documentation when useful.
+- Document complex or non-obvious code sections.
+
+## Best Practices
+- Prefer immutable variables (`let` instead of `let mut`) when possible.
+- Use strong typing rather than type aliases for clarity.
+- Leverage Rust's ownership system properly.
+- Avoid `unsafe` code unless absolutely necessary.
+- Use `clippy` to catch common mistakes. 
+
+# Rust Architecture Guidelines
+
+## Project Structure
+- Follow the modular structure in `src/`:
+  - `core/`: Core tfmcp functionality and abstractions
+  - `mcp/`: Model Context Protocol implementation
+  - `terraform/`: Terraform integration services
+  - `config/`: Configuration handling
+  - `shared/`: Shared utilities
+
+## Module Organization
+- Each module should have a clear, single responsibility.
+- Public APIs should be exposed through the module's `mod.rs` or `lib.rs`.
+- Keep implementation details private whenever possible.
+- Use feature flags for optional functionality.
+
+## Dependencies
+- Be conservative with external dependencies.
+- Evaluate new dependencies carefully:
+  - Is it actively maintained?
+  - Is it widely used/trusted?
+  - Would it be better to implement the functionality ourselves?
+- Pin dependency versions in Cargo.toml for reproducible builds.
+
+## Asynchronous Programming
+- Use `async/await` for asynchronous code.
+- Use `tokio` for async runtime.
+- Be careful with blocking operations in async contexts.
+- Consider using channels for communication between components. 
+

--- a/.cursor 2/rules/002_terraform.mdc
+++ b/.cursor 2/rules/002_terraform.mdc
@@ -1,0 +1,36 @@
+---
+description: Terraform standards and best practices for tfmcp.
+globs: **/*.tf, **/*.tfvars, **/*.hcl
+alwaysApply: false
+---
+
+# Terraform Standards
+
+## Version Support
+- Target Terraform 1.11.1 as the primary supported version.
+- Ensure backward compatibility with Terraform 1.0+ when possible.
+- Test with multiple Terraform versions for compatibility.
+
+## Terraform Parsing
+- Use the Terraform provided HCL parser when available.
+- Implement proper escaping and handling of HCL syntax.
+- Handle comments and formatting appropriately.
+
+## Configuration Analysis
+- Analyze Terraform configurations thoroughly:
+  - Check for resource dependencies
+  - Validate provider configurations
+  - Identify potential issues or optimizations
+- Support various Terraform resources and providers.
+
+## Best Practices
+- Follow HCL formatting conventions.
+- Respect Terraform state management principles.
+- Handle terraform.tfstate files with care.
+- Implement proper error handling for Terraform CLI operations.
+
+## Demo Environment
+- Maintain example/ directory with good Terraform examples.
+- Ensure the demo environment is self-contained and works out of the box.
+- Keep example/ code up to date with best practices. 
+

--- a/.cursor 2/rules/003_mcp.mdc
+++ b/.cursor 2/rules/003_mcp.mdc
@@ -1,0 +1,32 @@
+---
+description: MCP protocol implementation guidelines and standards.
+globs: **/mcp/**/*.rs
+alwaysApply: false
+---
+
+# MCP Protocol Implementation
+
+## Protocol Compliance
+- Follow the Model Context Protocol specification.
+- Implement required methods like `resources/list` and `prompts/list`.
+- Ensure proper JSON-RPC 2.0 formatting for all messages.
+- Handle protocol errors gracefully.
+
+## Server Implementation
+- Use stdin/stdout for communication in MCP server mode.
+- Implement proper error handling and response formatting.
+- Provide meaningful error messages for debugging.
+- Log MCP interactions appropriately.
+
+## Claude Desktop Integration
+- Ensure seamless integration with Claude Desktop.
+- Set up proper environment variables for Claude Desktop.
+- Support changing terraform directories at runtime.
+- Document integration steps clearly.
+
+## Security Considerations
+- Implement appropriate safeguards for sensitive operations.
+- Consider permission boundaries for terraform operations.
+- Validate inputs to prevent command injection.
+- Add safety mechanisms like confirmation prompts for destructive operations. 
+

--- a/.cursor 2/rules/README.md
+++ b/.cursor 2/rules/README.md
@@ -1,0 +1,37 @@
+# tfmcp Project Rules
+
+This directory contains the Cursor AI rules for the tfmcp project.
+
+## Structure
+
+- **project.json**: Global settings and rules for the entire project
+- **rust.json**: Rules specific to Rust code files
+- **terraform.json**: Rules specific to Terraform configuration files
+
+## Usage
+
+These rules are automatically applied by Cursor IDE when working with relevant files.
+No manual action is required to enable them.
+
+## Moving from .cursorrules
+
+This project is migrating from the legacy `.cursorrules` file to the new Project Rules system.
+The `.cursorrules` file is still maintained for backward compatibility but will eventually be removed.
+
+## Rules Philosophy
+
+1. **Consistency**: Maintain consistent coding style across the project
+2. **Clarity**: Promote clear, readable code with proper documentation
+3. **Efficiency**: Optimize workflows with helpful commands and automation
+4. **Security**: Follow best practices for secure coding and infrastructure
+
+## Custom Commands
+
+Use the Command Palette (Cmd+Shift+P) and type any of the registered commands:
+
+- `tfmcp:release` - Release a new version
+- `tfmcp:build` - Build the project
+- `tfmcp:test` - Run tests
+- `tfmcp:lint` - Run linter
+- `tfmcp:run` - Run the MCP server
+- `tfmcp:analyze` - Analyze Terraform code 

--- a/.cursor 2/rules/project.json
+++ b/.cursor 2/rules/project.json
@@ -1,0 +1,51 @@
+{
+  "description": "Global settings for the tfmcp project",
+  "include": ["**/*"],
+  "rules": [
+    "When working on this project, consider the Terraform Model Context Protocol design principles.",
+    "Always follow the Rust coding style guidelines.",
+    "This project uses Terraform 1.11.1 for compatibility with the latest features."
+  ],
+  "commands": {
+    "tfmcp:release": {
+      "description": "Release a new version of tfmcp",
+      "command": "bash Release.sh $1",
+      "args": [
+        {
+          "name": "version",
+          "description": "Version number (e.g. v0.1.0)",
+          "required": true
+        }
+      ]
+    },
+    "tfmcp:build": {
+      "description": "Build tfmcp",
+      "command": "cargo build --release"
+    },
+    "tfmcp:build:debug": {
+      "description": "Build tfmcp in debug mode",
+      "command": "cargo build"
+    },
+    "tfmcp:test": {
+      "description": "Run tfmcp tests",
+      "command": "cargo test"
+    },
+    "tfmcp:run": {
+      "description": "Run tfmcp MCP server",
+      "command": "cargo run -- mcp",
+      "env": {
+        "TFMCP_LOG_LEVEL": "debug",
+        "TFMCP_DEMO_MODE": "true"
+      }
+    }
+  },
+  "editorSettings": {
+    "tabSize": 4,
+    "insertSpaces": true,
+    "rulers": [100],
+    "formatOnPaste": true,
+    "formatOnType": true,
+    "trimTrailingWhitespace": true,
+    "insertFinalNewline": true
+  }
+} 

--- a/.cursor 2/rules/rust.json
+++ b/.cursor 2/rules/rust.json
@@ -1,0 +1,31 @@
+{
+  "description": "Rules for Rust code files",
+  "include": ["**/*.rs"],
+  "rules": [
+    "Follow the Rust style guide for this project.",
+    "Use Result and Option types for error handling where appropriate.",
+    "Document public functions and methods with rustdoc comments.",
+    "Avoid unnecessary dependencies.",
+    "Leverage Rust's type system for safety guarantees.",
+    "Handle errors gracefully with proper error propagation.",
+    "Use async/await for asynchronous operations."
+  ],
+  "commands": {
+    "tfmcp:lint": {
+      "description": "Run clippy linter",
+      "command": "cargo clippy --all-targets --all-features -- -D warnings"
+    },
+    "tfmcp:check": {
+      "description": "Check code without building",
+      "command": "cargo check"
+    },
+    "tfmcp:format": {
+      "description": "Format code",
+      "command": "cargo fmt"
+    },
+    "tfmcp:docs": {
+      "description": "Generate and open documentation",
+      "command": "cargo doc --open"
+    }
+  }
+} 

--- a/.cursor 2/rules/terraform.json
+++ b/.cursor 2/rules/terraform.json
@@ -1,0 +1,29 @@
+{
+  "description": "Rules for Terraform files in the project",
+  "include": ["**/*.tf", "**/*.tfvars", "**/*.hcl"],
+  "rules": [
+    "Use Terraform 1.11.1 for this project.",
+    "Follow HCL formatting best practices.",
+    "Document resource blocks with meaningful comments.",
+    "Use variables for reusable values.",
+    "Group related resources together.",
+    "Use modules for reusable components.",
+    "Add descriptions to variables and outputs."
+  ],
+  "commands": {
+    "tfmcp:analyze": {
+      "description": "Run analyze command on terraform project",
+      "command": "cargo run -- analyze -d $1",
+      "args": [
+        {
+          "name": "project_dir",
+          "description": "Terraform project directory",
+          "required": true
+        }
+      ]
+    }
+  },
+  "references": {
+    "files": [".terraform-version"]
+  }
+} 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tfmcp: Terraform Model Context Protocol Tool
+[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/nwiizo/tfmcp)](https://archestra.ai/mcp-catalog/nwiizo__tfmcp)
 
 *⚠️  This project includes production-ready security features but is still under active development. While the security system provides robust protection, please review all operations carefully in production environments. ⚠️*
 


### PR DESCRIPTION
Hi!

This PR adds the "Trust Score" badge from our new Open Source MCP catalog.

Our catalog evaluates MCP servers based on technical quality—like protocol feature implementation and dependency health—rather than vanity metrics like GitHub stars.

The scoring process is fully transparent and reproducible:
- Evaluation Script: https://github.com/archestra-ai/website/blob/main/app/app/mcp-catalog/scripts/evaluate-catalog.ts
- Your Server's Page: https://archestra.ai/mcp-catalog/nwiizo__tfmcp

The badge is designed to be respectful to the structure of your readme, example: [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/topoteretes/cognee/cognee-mcp)](https://archestra.ai/mcp-catalog/topoteretes__cognee__cognee-mcp)

Projects like Grafana MCP (https://github.com/grafana/mcp-grafana) are already participating. 

We believe that transparent and truly open source MCP catalog should help the community to identify great MCP servers like yours 😊

We'd appreciate your support by merging this PR!